### PR TITLE
Initialize without wallet_private_key

### DIFF
--- a/lib/errors.rb
+++ b/lib/errors.rb
@@ -28,7 +28,7 @@ class ::PiNetwork
         @txid = txid
     end
 
-    class WalletPrivateKeyNotFoundError < StandardError
+    class WalletPrivateSeedNotFoundError < StandardError
     end
   end
 end

--- a/lib/errors.rb
+++ b/lib/errors.rb
@@ -27,5 +27,8 @@ class ::PiNetwork
         @payment_id = payment_id
         @txid = txid
     end
+
+    class WalletPrivateKeyNotFoundError < StandardError
+    end
   end
 end

--- a/lib/pi_network.rb
+++ b/lib/pi_network.rb
@@ -13,10 +13,10 @@ class PiNetwork
   attr_reader :from_address
 
   def initialize(api_key, options = {})
-    private_key = options[:wallet_private_seed]
-    validate_private_seed_format!(private_key) if private_key.present?
+    wallet_private_seed = options[:wallet_private_seed]
+    validate_private_seed_format!(wallet_private_seed) if wallet_private_seed.present?
     @api_key = api_key
-    @account = load_account(wallet_private_key)
+    @account = load_account(wallet_private_seed)
     @base_url = options[:base_url] || "https://api.minepi.com"
 
     @open_payments = {}

--- a/lib/pi_network.rb
+++ b/lib/pi_network.rb
@@ -15,6 +15,7 @@ class PiNetwork
   def initialize(api_key, options = {})
     wallet_private_seed = options[:wallet_private_seed]
     validate_private_seed_format!(wallet_private_seed) if wallet_private_seed.present?
+
     @api_key = api_key
     @account = load_account(wallet_private_seed)
     @base_url = options[:base_url] || "https://api.minepi.com"

--- a/lib/pi_network.rb
+++ b/lib/pi_network.rb
@@ -12,8 +12,9 @@ class PiNetwork
   attr_reader :base_url
   attr_reader :from_address
 
-  def initialize(api_key, wallet_private_key, options = {})
-    validate_private_seed_format!(wallet_private_key)
+  def initialize(api_key, options = {})
+    private_key = options[:wallet_private_key]
+    validate_private_seed_format!(private_key) if private_key.present?
     @api_key = api_key
     @account = load_account(wallet_private_key)
     @base_url = options[:base_url] || "https://api.minepi.com"

--- a/lib/pi_network.rb
+++ b/lib/pi_network.rb
@@ -58,6 +58,10 @@ class PiNetwork
   end
 
   def submit_payment(payment_id)
+    raise Errors::WalletPrivateSeedNotFoundError.new(
+      "You need to initialize the SDK with wallet_private_seed to call this method."
+    ) if self.account.nil?
+
     payment = @open_payments[payment_id]
 
     if payment.nil? || payment["identifier"] != payment_id

--- a/lib/pi_network.rb
+++ b/lib/pi_network.rb
@@ -13,7 +13,7 @@ class PiNetwork
   attr_reader :from_address
 
   def initialize(api_key, options = {})
-    private_key = options[:wallet_private_key]
+    private_key = options[:wallet_private_seed]
     validate_private_seed_format!(private_key) if private_key.present?
     @api_key = api_key
     @account = load_account(wallet_private_key)

--- a/pinetwork.gemspec
+++ b/pinetwork.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = "pinetwork"
-  s.version     = "0.1.2"
+  s.version     = "0.2.0"
   s.summary     = "Pi Network Ruby"
   s.description = "Pi Network backend library for Ruby-based webservers."
   s.authors     = ["Pi Core Team"]


### PR DESCRIPTION
- base: #8 
- renamed `wallet_private_key` to `wallet_private_seed`
- `wallet_private_seed` is not required when initializing the SDK
- readme is already updated in the base branch