### PR TITLE
Increase Thread Safety

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,9 @@
+require 'rake/testtask'
+
+Rake::TestTask.new do |t|
+  t.libs << "test"
+  t.test_files = FileList["test/*.rb"]
+end
+
+desc "Run tests"
+task default: :test

--- a/lib/pinetwork.rb
+++ b/lib/pinetwork.rb
@@ -11,7 +11,7 @@ class PiNetwork
   attr_reader :base_url
   attr_reader :from_address
 
-  def initialize(api_key, wallet_private_key, faraday = Faraday.new, options = {})
+  def initialize(api_key:, wallet_private_key:, faraday: Faraday.new, options: {})
     validate_private_seed_format!(wallet_private_key)
     @api_key = api_key
     @account = load_account(wallet_private_key)

--- a/lib/pinetwork.rb
+++ b/lib/pinetwork.rb
@@ -49,7 +49,6 @@ class PiNetwork
       payment: payment_data,
     }
 
-    # response = Faraday.post(
     response = @faraday.post(
       base_url + "/v2/payments",
       request_body.to_json,

--- a/lib/pinetwork.rb
+++ b/lib/pinetwork.rb
@@ -144,7 +144,7 @@ class PiNetwork
 
   def handle_http_response(response, unknown_error_message = "An unknown error occurred while making an API request")
     unless response.status == 200
-      error_message = JSON.parse(response.body).dig("error_message") rescue unknown_error_message
+      error_message = extract_error_message(response.body, unknown_error_message)
       raise Errors::APIRequestError.new(error_message, response.status, response.body)
     end
 
@@ -222,5 +222,9 @@ class PiNetwork
   def validate_private_seed_format!(seed)
     raise StandardError.new("Private Seed should start with \"S\"") unless seed.upcase.start_with?("S")
     raise StandardError.new("Private Seed should be 56 characters") unless seed.length == 56
+  end
+
+  def extract_error_message(response_body, default_message)
+    JSON.parse(response_body).dig("error_message") rescue default_message
   end
 end

--- a/lib/pinetwork.rb
+++ b/lib/pinetwork.rb
@@ -11,13 +11,17 @@ class PiNetwork
   attr_reader :base_url
   attr_reader :from_address
 
+  BASE_URL = "https://api.minepi.com".freeze
+  MAINNET_HOST = "api.mainnet.minepi.com".freeze
+  TESTNET_HOST = "api.testnet.minepi.com".freeze
+
   def initialize(api_key:, wallet_private_key:, faraday: Faraday.new, options: {})
     validate_private_seed_format!(wallet_private_key)
     @api_key = api_key
     @account = load_account(wallet_private_key)
-    @base_url = options[:base_url] || "https://api.minepi.com"
-    @mainnet_host = options[:mainnet_host] || "api.mainnet.minepi.com"
-    @testnet_host = options[:testnet_host] || "api.testnet.minepi.com"
+    @base_url = options[:base_url] || BASE_URL
+    @mainnet_host = options[:mainnet_host] || MAINNET_HOST
+    @testnet_host = options[:testnet_host] || TESTNET_HOST
     @faraday = faraday
 
     @open_payments = {}

--- a/pinetwork.gemspec
+++ b/pinetwork.gemspec
@@ -5,7 +5,12 @@ Gem::Specification.new do |s|
   s.description = "Pi Network backend library for Ruby-based webservers."
   s.authors     = ["Pi Core Team"]
   s.email       = "support@minepi.com"
-  s.files       = ["lib/pinetwork.rb", "lib/errors.rb"]
+  s.files       = [
+    "lib/pinetwork.rb",
+    "lib/errors.rb",
+    "test/a2u_concurrency_test.rb",
+    "Rakefile"
+  ]
   s.homepage    = "https://github.com/pi-apps/pi-ruby"
   s.license     = "PiOS"
   s.add_runtime_dependency "stellar-sdk", "~> 0.29.0"

--- a/test/a2u_concurrency_test.rb
+++ b/test/a2u_concurrency_test.rb
@@ -1,0 +1,35 @@
+require 'minitest/autorun'
+require_relative '../lib/pinetwork'
+
+class A2UConcurrencyTest < Minitest::Test
+  def test_concurrent_create_payment
+    total_threads = 10000
+    api_key = "api-key"
+    wallet_private_key = "SC2L62EYF7LYF43L4OOSKUKDESRAFJZW3UW6RFZ57UY25VAMHTL2BFER"
+
+    threads = []
+    
+    faraday_stub = Minitest::Mock.new
+    pi = PiNetwork.new(api_key, wallet_private_key, faraday_stub)
+
+    total_threads.times do
+      threads << Thread.new do
+        faraday_response = Faraday::Response.new(
+          status: 200,
+          body: {identifier: SecureRandom.alphanumeric(12)}.to_json,
+          response_headers: {}
+        )
+        faraday_stub.expect(:post, faraday_response) do |url|
+          url == "https://api.minepi.com/v2/payments"
+        end
+        
+        payment_data = { amount: 1, memo: "test", metadata: {"info": "test"}, uid: "test-uid" }
+        payment_id = pi.create_payment(payment_data)
+      end
+    end
+    threads.each(&:join)
+
+    open_payments_after = pi.instance_variable_get(:@open_payments)
+    assert_equal(total_threads, open_payments_after.values.uniq.count, "open_payments got corrupted!")
+  end
+end

--- a/test/a2u_concurrency_test.rb
+++ b/test/a2u_concurrency_test.rb
@@ -10,7 +10,7 @@ class A2UConcurrencyTest < Minitest::Test
     threads = []
     
     faraday_stub = Minitest::Mock.new
-    pi = PiNetwork.new(api_key, wallet_private_key, faraday_stub)
+    pi = PiNetwork.new(api_key: api_key, wallet_private_key: wallet_private_key, faraday: faraday_stub)
 
     total_threads.times do
       threads << Thread.new do


### PR DESCRIPTION
- base: #17 
- named param for constructor to support test case
- adds a test that creates multiple payments in different threads
- wrap `@open_payments` access with mutex