### PR TITLE
[Fix] Using BigDecimal to avoid rounding issue

### DIFF
--- a/lib/pinetwork.rb
+++ b/lib/pinetwork.rb
@@ -80,7 +80,7 @@ class PiNetwork
       @from_address = payment["from_address"]
 
       transaction_data = {
-        amount: payment["amount"],
+        amount: BigDecimal(payment["amount"].to_s),
         identifier: payment["identifier"],
         recipient: payment["to_address"]
       }

--- a/lib/pinetwork.rb
+++ b/lib/pinetwork.rb
@@ -16,7 +16,8 @@ class PiNetwork
   TESTNET_HOST = "api.testnet.minepi.com".freeze
 
   def initialize(api_key:, wallet_private_key:, faraday: Faraday.new, options: {})
-    validate_private_seed_format!(wallet_private_key)
+    validate_private_seed!(wallet_private_key)
+
     @api_key = api_key
     @account = load_account(wallet_private_key)
     @base_url = options[:base_url] || BASE_URL
@@ -219,9 +220,12 @@ class PiNetwork
     raise ArgumentError.new("Missing recipient") if options[:recipient] && !data[:recipient].present?
   end
 
-  def validate_private_seed_format!(seed)
-    raise StandardError.new("Private Seed should start with \"S\"") unless seed.upcase.start_with?("S")
-    raise StandardError.new("Private Seed should be 56 characters") unless seed.length == 56
+  def validate_private_seed!(seed)
+    begin
+      Stellar::Util::StrKey.check_decode(:seed, seed)
+    rescue StandardError
+      raise StandardError.new("Invalid Private Seed")
+    end
   end
 
   def extract_error_message(response_body, default_message)

--- a/pinetwork.gemspec
+++ b/pinetwork.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = "pinetwork"
-  s.version     = "0.1.5"
+  s.version     = "0.1.6"
   s.summary     = "Pi Network Ruby"
   s.description = "Pi Network backend library for Ruby-based webservers."
   s.authors     = ["Pi Core Team"]


### PR DESCRIPTION
# [Fix] Using BigDecimal to avoid rounding issue

- amount in the `payment_data` is now wrapped with BigDecimal
- improving seed checking when initializing the SDK