### PR TITLE
Add more robust error handling for transaction submission

### DIFF
--- a/lib/pinetwork.rb
+++ b/lib/pinetwork.rb
@@ -234,7 +234,7 @@ class PiNetwork
         tx_error_code, op_error_code = parse_horizon_error_response(response._response.body)
         raise Errors::TxSubmissionError.new(tx_error_code, op_error_code)
       elsif error_type != 5 # Some unexpected_status_code
-        # Hijacking TxSubmissionError here so we don't have to make a new Error for an unlikely response to encounter
+        # Repurposing TxSubmissionError here so we don't have to make a new Error for an unlikely response to encounter
         raise Errors::TxSubmissionError.new("unexpected_response_code", [status])
       end
 

--- a/lib/pinetwork.rb
+++ b/lib/pinetwork.rb
@@ -205,7 +205,7 @@ class PiNetwork
       time_bounds: time_bounds
     )
 
-    transaction = transaction_builder.add_operation(payment_operation).set_timeout(180000).build
+    transaction = transaction_builder.add_operation(payment_operation).build
 
     # Using max_time instead of time_bounds.max_time because it seems the Stellar SDK adds a substantial offset
     # upon initialization

--- a/lib/pinetwork.rb
+++ b/lib/pinetwork.rb
@@ -212,7 +212,7 @@ class PiNetwork
       response = self.client.submit_transaction(tx_envelope: envelope)
       txid = response._response.body["id"]
 
-      if txid.present? return txid
+      return txid if txid.present?
 
       # TODO: For now, assume txid.nil? indicates some special uncaught error state; need to see if ALL errors are
       #       ending up with nil txid instead of raising an exception

--- a/lib/pinetwork.rb
+++ b/lib/pinetwork.rb
@@ -245,7 +245,7 @@ class PiNetwork
       # No need to parse the response if we already formatted the exception in the `begin` block
       raise error
     rescue => error
-      tx_error_code, op_error_code = parse_horizon_error_response(error.response&.dig(:body))
+      tx_error_code, op_error_code = parse_horizon_error_response(error&.response&.dig(:body))
       raise Errors::TxSubmissionError.new(tx_error_code, op_error_code)
     end
   end

--- a/lib/pinetwork.rb
+++ b/lib/pinetwork.rb
@@ -214,7 +214,8 @@ class PiNetwork
 
   def parse_horizon_error_response(body)
     result_codes = body&.dig("extras", "result_codes")
-    tx_error_code, op_error_code = result_codes&.dig("transaction"), result_codes&.dig("operations")
+    tx_error_code = result_codes&.dig("transaction") || "unknown"
+    op_error_code = result_codes&.dig("operations") || "unknown"
 
     return tx_error_code, op_error_code
   end

--- a/lib/pinetwork.rb
+++ b/lib/pinetwork.rb
@@ -161,7 +161,7 @@ class PiNetwork
   end
 
   def set_horizon_client(network)
-    host = (network.starts_with? "Pi Network") ? @mainnet_host : @testnet_host
+    host = (network.start_with? "Pi Network") ? @mainnet_host : @testnet_host
     horizon = "https://#{host}"
 
     client = Stellar::Horizon::Client.new(host: host, horizon: horizon)

--- a/lib/pinetwork.rb
+++ b/lib/pinetwork.rb
@@ -189,9 +189,9 @@ class PiNetwork
 
     # Add time_bounds so we can place a time limit on the transaction and try the same
     # one multiple times (in case of Horizon server errors)
-    now, timeout = Time.now.to_i, TX_SUBMISSION_TIMEOUT_SECONDS
-    max_time = now + timeout
-    time_bounds = Stellar::TimeBounds.new(min_time: now, max_time: max_time)
+    min_time = Time.now.utc.to_i
+    max_time = min_time + TX_SUBMISSION_TIMEOUT_SECONDS
+    time_bounds = Stellar::TimeBounds.new(min_time:, max_time:)
 
     payment_operation = Stellar::Operation.payment(destination: recipient, amount: amount.to_payment)
 

--- a/pinetwork.gemspec
+++ b/pinetwork.gemspec
@@ -1,20 +1,23 @@
 Gem::Specification.new do |s|
   s.name        = "pinetwork"
-  s.version     = "0.1.5"
+  s.version     = "0.1.6"
   s.summary     = "Pi Network Ruby"
-  s.description = "Pi Network backend library for Ruby-based webservers."
+  s.description = "Pi Network backend library for Ruby-based web servers."
   s.authors     = ["Pi Core Team"]
   s.email       = "support@minepi.com"
   s.files       = [
     "lib/pinetwork.rb",
     "lib/errors.rb",
     "test/a2u_concurrency_test.rb",
+    "test/transaction_submission_test.rb",
     "Rakefile"
   ]
   s.homepage    = "https://github.com/pi-apps/pi-ruby"
   s.license     = "PiOS"
   s.add_runtime_dependency "stellar-sdk", "~> 0.31.0"
   s.add_runtime_dependency "faraday", "~> 1.6.0"
+  s.add_development_dependency "minitest", "~> 5.25.4"
+  s.add_development_dependency "mocha", "~> 2.7.1"
   s.metadata = {
     "documentation_uri" => "https://github.com/pi-apps/pi-ruby",
   }

--- a/test/a2u_concurrency_test.rb
+++ b/test/a2u_concurrency_test.rb
@@ -5,7 +5,7 @@ class A2UConcurrencyTest < Minitest::Test
   def test_concurrent_create_payment
     total_threads = 10000
     api_key = "api-key"
-    wallet_private_key = "SC2L62EYF7LYF43L4OOSKUKDESRAFJZW3UW6RFZ57UY25VAMHTL2BFER"
+    wallet_private_key = Stellar::KeyPair.random.seed
 
     threads = []
 

--- a/test/a2u_concurrency_test.rb
+++ b/test/a2u_concurrency_test.rb
@@ -8,7 +8,7 @@ class A2UConcurrencyTest < Minitest::Test
     wallet_private_key = "SC2L62EYF7LYF43L4OOSKUKDESRAFJZW3UW6RFZ57UY25VAMHTL2BFER"
 
     threads = []
-    
+
     faraday_stub = Minitest::Mock.new
     pi = PiNetwork.new(api_key: api_key, wallet_private_key: wallet_private_key, faraday: faraday_stub)
 
@@ -22,7 +22,7 @@ class A2UConcurrencyTest < Minitest::Test
         faraday_stub.expect(:post, faraday_response) do |url|
           url == "https://api.minepi.com/v2/payments"
         end
-        
+
         payment_data = { amount: 1, memo: "test", metadata: {"info": "test"}, uid: "test-uid" }
         payment_id = pi.create_payment(payment_data)
       end

--- a/test/transaction_submission_test.rb
+++ b/test/transaction_submission_test.rb
@@ -39,7 +39,7 @@ class TransactionSubmissionTest < Minitest::Test
 
     # Then set up the necessary data
     api_key = "api-key"
-    wallet_private_key = "SC2L62EYF7LYF43L4OOSKUKDESRAFJZW3UW6RFZ57UY25VAMHTL2BFER"
+    wallet_private_key = Stellar::KeyPair.random.seed
     @pi = PiNetwork.new(api_key: api_key, wallet_private_key: wallet_private_key)
 
     from_wallet_keypair = Stellar::KeyPair.from_seed(wallet_private_key)

--- a/test/transaction_submission_test.rb
+++ b/test/transaction_submission_test.rb
@@ -52,7 +52,7 @@ class TransactionSubmissionTest < Minitest::Test
       "network" => "Pi Network",
       "amount" => 3.14,
       "from_address" => account.address,
-      "to_address" => "GDCTIXFMVAHYKHRH6SN5PEH5432426NTV2LYFHRP4BBGN5SR4GPCPT2A"
+      "to_address" => Stellar::KeyPair.random.address
     }
 
     @txid = "01234abcde"

--- a/test/transaction_submission_test.rb
+++ b/test/transaction_submission_test.rb
@@ -1,0 +1,52 @@
+require 'minitest/autorun'
+require 'ostruct'
+require 'json'
+require 'stellar-sdk'
+require_relative '../lib/pinetwork'
+
+class TransactionSubmissionTest < Minitest::Test
+  # test_payment_submission
+  # test_payment_400_response
+  # test_payment_500_response # e.g. 503
+  # test_payment_retry
+
+  def test_transaction_submission
+    api_key = "api-key"
+    wallet_private_key = "SC2L62EYF7LYF43L4OOSKUKDESRAFJZW3UW6RFZ57UY25VAMHTL2BFER"
+    pi = PiNetwork.new(api_key: api_key, wallet_private_key: wallet_private_key)
+
+    from_wallet_keypair = Stellar::KeyPair.from_seed(wallet_private_key)
+    from_address = from_wallet_keypair.public_key
+
+    payment_id = "1234abcd"
+    payment = {
+      "identifier" => payment_id,
+      "network" => "Pi Network",
+      "amount" => 3.14,
+      "from_address" => from_address,
+      "to_address" => "GDCTIXFMVAHYKHRH6SN5PEH5432426NTV2LYFHRP4BBGN5SR4GPCPT2A"
+    }
+
+    txid = "01234abcde"
+    horizon_mock = Minitest::Mock.new
+    account_info_response = OpenStruct.new(sequence: 1) # Used during build_a2u_transaction
+    submit_transaction_response = JSON.parse(
+      { _response: { body: { "id": txid } } }.to_json,
+      { object_class: OpenStruct }
+    )
+    horizon_mock.expect(:account_info, account_info_response, [payment["from_address"]])
+    horizon_mock.expect(:submit_transaction, submit_transaction_response) do |args|
+      args[:tx_envelope] != nil
+    end
+
+    pi.stub(:get_payment, payment) do # Avoid API call to MA BE
+      pi.stub(:client, horizon_mock) do
+        pi.stub(:account, OpenStruct.new(address: from_address, keypair: from_wallet_keypair)) do
+          assert_equal(pi.submit_payment(payment_id), txid, "Returned txid does not match expected value")
+
+          horizon_mock.verify
+        end
+      end
+    end
+  end
+end

--- a/test/transaction_submission_test.rb
+++ b/test/transaction_submission_test.rb
@@ -65,27 +65,6 @@ class TransactionSubmissionTest < Minitest::Test
     set_tx_submission_timers(30, 5)
   end
 
-  def test_submission_timeout
-    # Hard-coding enough responses to time out based on current parameters for set_tx_submission_timers(5, 1)
-    submit_transaction_responses = [
-      { _response: { body: { title: "Historical DB Is Too Stale" }, status: 503 } }, # 0 sec
-      { _response: { body: { title: "Historical DB Is Too Stale" }, status: 503 } }, # 1
-      { _response: { body: { title: "Historical DB Is Too Stale" }, status: 503 } }, # 2
-      { _response: { body: { title: "Historical DB Is Too Stale" }, status: 503 } }, # 3
-      { _response: { body: { title: "Historical DB Is Too Stale" }, status: 503 } }, # 4
-      { _response: { body: { title: "Historical DB Is Too Stale" }, status: 503 } }, # 5; At timeout limit, raise here
-      { _response: { body: { title: "Historical DB Is Too Stale" }, status: 503 } }, # Just to avoid possible race condition effects
-    ]
-    horizon_mock = setup_horizon_mock(submit_transaction_responses)
-
-    pi.stubs(:client).returns(horizon_mock)
-
-    error = assert_raises(PiNetwork::Errors::TxSubmissionError) { pi.submit_payment(payment["identifier"]) }
-
-    assert_equal("tx_too_late", error.tx_error_code, "Raised error has wrong tx error code")
-    assert_nil(error.op_error_codes, "Raised error has unexpected op error codes")
-  end
-
   def test_server_error_response
     submit_transaction_responses = [
       { _response: { body: { title: "Historical DB Is Too Stale" }, status: 503 } }, # Server error response first

--- a/test/transaction_submission_test.rb
+++ b/test/transaction_submission_test.rb
@@ -1,52 +1,86 @@
 require 'minitest/autorun'
+require 'mocha/minitest'
 require 'ostruct'
 require 'json'
 require 'stellar-sdk'
 require_relative '../lib/pinetwork'
+require_relative '../lib/errors'
+
+def set_tx_submission_timers(timeout, retry_delay)
+  # Disable warnings that will clog up the terminal
+  $VERBOSE = nil
+
+  PiNetwork.const_set(:TX_SUBMISSION_TIMEOUT_SECONDS, timeout)
+  PiNetwork.const_set(:TX_RETRY_DELAY_SECONDS, retry_delay)
+
+  $VERBOSE = true
+end
+
+def setup_horizon_mock(submit_transaction_response_hash)
+  horizon_mock = mock()
+  account_info_response = OpenStruct.new(sequence: 1) # Used during build_a2u_transaction
+  submit_transaction_response = JSON.parse(submit_transaction_response_hash.to_json, { object_class: OpenStruct })
+
+  horizon_mock.expects(:account_info).returns(account_info_response).at_least_once
+  horizon_mock.expects(:submit_transaction).returns(submit_transaction_response).at_least_once
+
+  horizon_mock
+end
 
 class TransactionSubmissionTest < Minitest::Test
-  # test_payment_submission
-  # test_payment_400_response
-  # test_payment_500_response # e.g. 503
-  # test_payment_retry
+  attr_reader :pi, :account, :payment, :txid
 
-  def test_transaction_submission
+  # TODO:
+  # test_payment_400_response
+  # test_payment_timeout
+
+  def setup
+    # Adjust submission timeout values to speed the test up
+    set_tx_submission_timers(5, 1)
+
+    # Then set up the necessary data
     api_key = "api-key"
     wallet_private_key = "SC2L62EYF7LYF43L4OOSKUKDESRAFJZW3UW6RFZ57UY25VAMHTL2BFER"
-    pi = PiNetwork.new(api_key: api_key, wallet_private_key: wallet_private_key)
+    @pi = PiNetwork.new(api_key: api_key, wallet_private_key: wallet_private_key)
 
     from_wallet_keypair = Stellar::KeyPair.from_seed(wallet_private_key)
     from_address = from_wallet_keypair.public_key
+    @account = OpenStruct.new(address: from_address, keypair: from_wallet_keypair)
 
     payment_id = "1234abcd"
-    payment = {
+    @payment = {
       "identifier" => payment_id,
       "network" => "Pi Network",
       "amount" => 3.14,
-      "from_address" => from_address,
+      "from_address" => account.address,
       "to_address" => "GDCTIXFMVAHYKHRH6SN5PEH5432426NTV2LYFHRP4BBGN5SR4GPCPT2A"
     }
 
-    txid = "01234abcde"
-    horizon_mock = Minitest::Mock.new
-    account_info_response = OpenStruct.new(sequence: 1) # Used during build_a2u_transaction
-    submit_transaction_response = JSON.parse(
-      { _response: { body: { "id": txid } } }.to_json,
-      { object_class: OpenStruct }
-    )
-    horizon_mock.expect(:account_info, account_info_response, [payment["from_address"]])
-    horizon_mock.expect(:submit_transaction, submit_transaction_response) do |args|
-      args[:tx_envelope] != nil
-    end
+    @txid = "01234abcde"
 
-    pi.stub(:get_payment, payment) do # Avoid API call to MA BE
-      pi.stub(:client, horizon_mock) do
-        pi.stub(:account, OpenStruct.new(address: from_address, keypair: from_wallet_keypair)) do
-          assert_equal(pi.submit_payment(payment_id), txid, "Returned txid does not match expected value")
+    pi.stubs(:get_payment).returns(payment) # Avoid API call to platform BE
+    pi.stubs(:account).returns(account)
+  end
 
-          horizon_mock.verify
-        end
-      end
-    end
+  def teardown
+    set_tx_submission_timers(30, 5)
+  end
+
+  def test_user_error_response
+    submit_transaction_response = { _response: { body: { title: "Transaction Failed" }, status: 400 } }
+    horizon_mock = setup_horizon_mock(submit_transaction_response)
+
+    pi.stubs(:client).returns(horizon_mock)
+
+    assert_raises(StandardError) { pi.submit_payment(payment["identifier"]) }
+  end
+
+  def test_success_response
+    submit_transaction_response = { _response: { body: { "id": txid }, status: 200 } }
+    horizon_mock = setup_horizon_mock(submit_transaction_response)
+
+    pi.stubs(:client).returns(horizon_mock)
+
+    assert_equal(pi.submit_payment(payment["identifier"]), txid, "Returned txid does not match expected value")
   end
 end

--- a/test/transaction_submission_test.rb
+++ b/test/transaction_submission_test.rb
@@ -35,10 +35,6 @@ end
 class TransactionSubmissionTest < Minitest::Test
   attr_reader :pi, :account, :payment, :txid
 
-  # TODO:
-  # test_payment_500_response
-  # test_payment_timeout
-
   def setup
     # Adjust submission timeout values to speed the test up
     set_tx_submission_timers(5, 1)
@@ -69,6 +65,27 @@ class TransactionSubmissionTest < Minitest::Test
 
   def teardown
     set_tx_submission_timers(30, 5)
+  end
+
+  def test_submission_timeout
+    # Hard-coding enough responses to time out based on current parameters for set_tx_submission_timers(5, 1)
+    submit_transaction_responses = [
+      { _response: { body: { title: "Historical DB Is Too Stale" }, status: 503 } }, # 0 sec
+      { _response: { body: { title: "Historical DB Is Too Stale" }, status: 503 } }, # 1
+      { _response: { body: { title: "Historical DB Is Too Stale" }, status: 503 } }, # 2
+      { _response: { body: { title: "Historical DB Is Too Stale" }, status: 503 } }, # 3
+      { _response: { body: { title: "Historical DB Is Too Stale" }, status: 503 } }, # 4
+      { _response: { body: { title: "Historical DB Is Too Stale" }, status: 503 } }, # 5; At timeout limit, raise here
+      { _response: { body: { title: "Historical DB Is Too Stale" }, status: 503 } }, # Just to avoid possible race condition effects
+    ]
+    horizon_mock = setup_horizon_mock(submit_transaction_responses)
+
+    pi.stubs(:client).returns(horizon_mock)
+
+    error = assert_raises(PiNetwork::Errors::TxSubmissionError) { pi.submit_payment(payment["identifier"]) }
+
+    assert_equal("tx_too_late", error.tx_error_code, "Raised error has wrong tx error code")
+    assert_nil(error.op_error_codes, "Raised error has unexpected op error codes")
   end
 
   def test_server_error_response

--- a/test/transaction_submission_test.rb
+++ b/test/transaction_submission_test.rb
@@ -1,8 +1,6 @@
 require 'minitest/autorun'
 require 'mocha/minitest'
 require 'ostruct'
-require 'json'
-require 'stellar-sdk'
 require_relative '../lib/pinetwork'
 require_relative '../lib/errors'
 


### PR DESCRIPTION
Previous behavior: `submit_transaction` would often return a nil `txid` when receiving a failure response from Horizon. An error handler was added some time ago that takes care of exceptions raised from within the Horizon client API call itself, but other failure responses appear to bypass this by yielding a successful return value (one that doesn't have a txid).

New behavior: `submit_transaction` will now parse the Horizon API call's return value more robustly. It will raise an error on any non-success code, except for 5xx codes, where it will re-attempt the payment until it either succeeds or times out. Transactions also now have time bounds to allow for multiple attempts without risking double-payment.